### PR TITLE
bareun 설치 명령어 수정

### DIFF
--- a/samples/colab_bareun_gpu.ipynb
+++ b/samples/colab_bareun_gpu.ipynb
@@ -32,7 +32,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -40,17 +40,9 @@
         "id": "KIyzfCUKXrUq",
         "outputId": "b77fdaaa-0126-414d-dc32-5b60cba70c2f"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "bareun-v2.0.0.linux-x86_64.deb\tsample_data\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "!curl -OLJks -H \"uname:$(uname -a)\" https://bareun.ai/api/get\n",
+        "!curl -LJks -H \"uname:$(uname -a)\" https://bareun.ai/api/get -o bareun-linux.deb\n",
         "!ls"
       ]
     },
@@ -115,7 +107,7 @@
         }
       ],
       "source": [
-        "!dpkg -i bareun-v2.0.0.linux-x86_64.deb"
+        "!dpkg -i bareun-linux.deb"
       ]
     },
     {


### PR DESCRIPTION
- 버전에 관계 없이 "bareun-linux.deb"로 받도록 수정